### PR TITLE
Allow no support package in LocalPackageMeshLoader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Allow no `support_package` in `LocalPackageMeshLoader`
+
 ### Removed
 
 

--- a/src/compas_robots/resources/basic.py
+++ b/src/compas_robots/resources/basic.py
@@ -165,7 +165,10 @@ class LocalPackageMeshLoader(AbstractMeshLoader):
         super(LocalPackageMeshLoader, self).__init__()
         self.path = path
         self.support_package = support_package
-        self.schema_prefix = "package://" + self.support_package + "/"
+        if support_package is None or support_package == "":
+            self.schema_prefix = "package://"
+        else:
+            self.schema_prefix = "package://" + self.support_package + "/"
 
     def build_path(self, *path_parts):
         """Returns the building path.

--- a/src/compas_robots/resources/basic.py
+++ b/src/compas_robots/resources/basic.py
@@ -156,16 +156,17 @@ class LocalPackageMeshLoader(AbstractMeshLoader):
     ----------
     path : str
         Path where the package is stored locally.
-    support_package : str
+    support_package : str, optional
         Name of the support package containing URDF, Meshes
-        and additional assets, e.g. 'abb_irb4400_support'
+        and additional assets, e.g. 'abb_irb4400_support'.
+        Default is None.
     """
 
-    def __init__(self, path, support_package):
+    def __init__(self, path, support_package = None):
         super(LocalPackageMeshLoader, self).__init__()
         self.path = path
         self.support_package = support_package
-        if support_package is None or support_package == "":
+        if not support_package:
             self.schema_prefix = "package://"
         else:
             self.schema_prefix = "package://" + self.support_package + "/"

--- a/src/compas_robots/resources/basic.py
+++ b/src/compas_robots/resources/basic.py
@@ -183,10 +183,7 @@ class LocalPackageMeshLoader(AbstractMeshLoader):
         -------
         str
         """
-        if not self.support_package:
-            return os.path.join(self.path, *path_parts)
-        else:
-            return os.path.join(self.path, self.support_package, *path_parts)
+        return os.path.join(self.path, self.support_package, *path_parts)
 
     def load_urdf(self, file):
         """Load a URDF file from local storage.

--- a/src/compas_robots/resources/basic.py
+++ b/src/compas_robots/resources/basic.py
@@ -162,7 +162,7 @@ class LocalPackageMeshLoader(AbstractMeshLoader):
         Default is None.
     """
 
-    def __init__(self, path, support_package = None):
+    def __init__(self, path, support_package=None):
         super(LocalPackageMeshLoader, self).__init__()
         self.path = path
         self.support_package = support_package

--- a/src/compas_robots/resources/basic.py
+++ b/src/compas_robots/resources/basic.py
@@ -183,7 +183,10 @@ class LocalPackageMeshLoader(AbstractMeshLoader):
         -------
         str
         """
-        return os.path.join(self.path, self.support_package, *path_parts)
+        if not self.support_package:
+            return os.path.join(self.path, *path_parts)
+        else:
+            return os.path.join(self.path, self.support_package, *path_parts)
 
     def load_urdf(self, file):
         """Load a URDF file from local storage.

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,13 @@
+import os
+
+from compas_robots.resources import LocalPackageMeshLoader
+
+
+def test_build_path():
+    loader_with_support_package = LocalPackageMeshLoader("meshes", "ur_description")
+    assert os.path.join("meshes", "ur_description", "urdf", "some.urdf") == loader_with_support_package.build_path(
+        "urdf", "some.urdf"
+    )
+
+    loader_without_support_package = LocalPackageMeshLoader("meshes")
+    assert os.path.join("meshes", "urdf", "some.urdf") == loader_without_support_package.build_path("urdf", "some.urdf")


### PR DESCRIPTION
This will allow the LocalPackageMeshLoader to process robot 
 packages that does not have a support_package sub folder. This is used for loading packages from the local_cache_directory of the RosFileServerLoader. 

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
