### PR TITLE
Removed all `model` input in `RobotModelObject.__init__`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fixed all four `RobotModelObject.__init__` to not accept `model` input.
+  The model is set at `SceneObject.item` and is available from `BaseRobotModelObject.model`.
 * Fixed `self.configuration` unassigned error when `RobotModelObject` is being initialized by `Scene.add()`.
 * Dropped support for Python 3.8 and updated compas requirements to 2.3
 * Fixed `robotmodelobject` attribute.

--- a/src/compas_robots/blender/scene/robotmodelobject.py
+++ b/src/compas_robots/blender/scene/robotmodelobject.py
@@ -20,10 +20,6 @@ class RobotModelObject(BlenderSceneObject, BaseRobotModelObject):
 
     Parameters
     ----------
-    model : :class:`~compas_robots.RobotModel`
-        Robot model.
-    collection : str | :blender:`bpy.types.Collection`
-        The Blender scene collection to which the object(s) created by this scene object belong to.
     **kwargs : dict, optional
         Additional keyword arguments.
         For more info,
@@ -31,8 +27,8 @@ class RobotModelObject(BlenderSceneObject, BaseRobotModelObject):
 
     """
 
-    def __init__(self, model: RobotModel, collection: Optional[Union[str, bpy.types.Collection]] = None, **kwargs: Any):
-        super().__init__(model=model, collection=collection or model.name, **kwargs)
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
 
     def transform(self, native_mesh: bpy.types.Object, transformation: Transformation) -> None:
         """Transform the mesh of a robot model.

--- a/src/compas_robots/blender/scene/robotmodelobject.py
+++ b/src/compas_robots/blender/scene/robotmodelobject.py
@@ -1,7 +1,5 @@
 from typing import Any
 from typing import List
-from typing import Optional
-from typing import Union
 
 import bpy  # type: ignore
 import compas_blender
@@ -11,7 +9,6 @@ from compas.datastructures import Mesh
 from compas.geometry import Transformation
 from compas_blender.scene import BlenderSceneObject
 
-from compas_robots import RobotModel
 from compas_robots.scene import BaseRobotModelObject
 
 

--- a/src/compas_robots/ghpython/scene/robotmodelobject.py
+++ b/src/compas_robots/ghpython/scene/robotmodelobject.py
@@ -14,16 +14,14 @@ class RobotModelObject(GHSceneObject, BaseRobotModelObject):
 
     Parameters
     ----------
-    model : :class:`~compas_robots.RobotModel`
-        Robot model.
     **kwargs : dict, optional
         Additional keyword arguments.
         See :class:`~compas_ghpython.scene.GHSceneObject` and :class:`~compas_robots.scene.BaseRobotModelObject` for more info.
 
     """
 
-    def __init__(self, model, **kwargs):
-        super(RobotModelObject, self).__init__(model=model, **kwargs)
+    def __init__(self, **kwargs):
+        super(RobotModelObject, self).__init__(**kwargs)
 
     def transform(self, native_mesh, transformation):
         T = transformation_to_rhino(transformation)

--- a/src/compas_robots/rhino/scene/robotmodelobject.py
+++ b/src/compas_robots/rhino/scene/robotmodelobject.py
@@ -22,16 +22,14 @@ class RobotModelObject(RhinoSceneObject, BaseRobotModelObject):
 
     Parameters
     ----------
-    model : :class:`~compas_robots.RobotModel`
-        Robot model.
     **kwargs : dict, optional
         Additional keyword arguments.
         For more info, see :class:`RhinoSceneObject` and :class:`RobotModelObject`.
 
     """
 
-    def __init__(self, model, **kwargs):
-        super(RobotModelObject, self).__init__(model=model, **kwargs)
+    def __init__(self, **kwargs):
+        super(RobotModelObject, self).__init__(**kwargs)
 
     def transform(self, native_mesh, transformation):
         T = transformation_to_rhino(transformation)


### PR DESCRIPTION
I'm not sure since which version of compas that the Scene will no longer pass model as parameter to the __init__ of RobotModelObject. This is pass as `item` now. The model is set at `SceneObject.item` and previously @PingHsunTsai have already made it available at `BaseRobotModelObject.model`. 

That change had not been updated to the other RobotModelObjects at Rhino GH and blender. So here it is.

This fixes the error message:
```
Message: init() takes exactly 2 arguments (4 given)

Traceback:
line 116, in add, “C:\Users\alici\AppData\Roaming\McNeel\Rhinoceros\7.0\scripts\compas\scene\scene.py”
line 10, in , “C:\Users\alici\AppData\Local\Temp\TempScript.py”
```

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
