### PR TITLE
adapted import to draw_mesh to newly removed utilities module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Fixed no scene object registered for `RobotModel` in context `Rhino`.
-* Adapted import inside `RobotModelObject` to lastes changes in `compas_ghpython`.
+* Adapted import inside `RobotModelObject` to latest changes in `compas_ghpython`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Adapted import inside `RobotModelObject` to lastes changes in `compas_ghpython`.
+
 ### Removed
 
 

--- a/src/compas_robots/ghpython/scene/robotmodelobject.py
+++ b/src/compas_robots/ghpython/scene/robotmodelobject.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import compas_ghpython
+from compas_ghpython.drawing import draw_mesh
 from compas_ghpython.scene import GHSceneObject
 from compas_rhino.conversions import transformation_to_rhino
 
@@ -46,7 +46,7 @@ class RobotModelObject(GHSceneObject, BaseRobotModelObject):
         color = color.rgba255 if color else None
 
         vertices, faces = geometry.to_vertices_and_faces(triangulated=False)
-        mesh = compas_ghpython.draw_mesh(vertices, faces, color=color)
+        mesh = draw_mesh(vertices, faces, color=color)
 
         # Try to fix invalid meshes
         if not mesh.IsValid:


### PR DESCRIPTION
This depends on https://github.com/compas-dev/compas/pull/1391

Removed first-level import for drawing functions in the above PR. Drawing functions are now imported from `compas_ghpython.drawing`.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
